### PR TITLE
Apply @instance and @name to 'get' when defined in Object.defineProperty

### DIFF
--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -231,6 +231,37 @@ Visitor.prototype.visitNodeComments = function(node, parser, filename) {
 
     var BLOCK_COMMENT = 'Block';
 
+    if (node.type === Syntax.ExpressionStatement &&
+        node.expression.callee &&
+        node.expression.callee.type === Syntax.MemberExpression &&
+        node.expression.callee.object.name === 'Object' &&
+        node.expression.callee.property.name === 'defineProperty') {
+        node.expression.arguments[2].properties.forEach(function (propertyNode) {
+            if (propertyNode.key.name !== 'get') {
+                return;
+            }
+
+            var commentNode;
+            var propertyName = node.expression.arguments[1].value;
+            var newComments = '*\r\n* @name ' + propertyName +
+                '\r\n* @instance\r\n';
+
+            if (!propertyNode.leadingComments) {
+                propertyNode.leadingComments = [{
+                    loc: propertyNode.loc,
+                    range: propertyNode.range,
+                    type: 'Block',
+                    raw: '',
+                    value: ''
+                }];
+            }
+
+            commentNode = propertyNode.leadingComments[0];
+            commentNode.value = newComments + commentNode.value;
+            commentNode.raw = '/*' + commentNode.value + '\r\n*/';
+        });
+    }
+
     if ( !hasJsdocComments(node) && (!node.type || node.type !== BLOCK_COMMENT) ) {
         return true;
     }

--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -237,7 +237,8 @@ Visitor.prototype.visitNodeComments = function(node, parser, filename) {
         node.expression.callee &&
         node.expression.callee.type === Syntax.MemberExpression &&
         node.expression.callee.object.name === 'Object' &&
-        node.expression.callee.property.name === 'defineProperty') {
+        node.expression.callee.property.name === 'defineProperty' &&
+        node.expression.arguments[2].properties) {
         // node.expression.arguments[2] is the definition object passed to 'defineProperty'
         node.expression.arguments[2].properties.forEach(function (propertyNode) {
             if (propertyNode.key.name !== 'get') {
@@ -245,10 +246,9 @@ Visitor.prototype.visitNodeComments = function(node, parser, filename) {
             }
 
             var commentNode;
-            // get the name of the property being defined
             var propertyName = node.expression.arguments[1].value;
-            var newComments = '*\r\n* @name ' + propertyName +
-                '\r\n* @instance\r\n';
+            var newComments = '*\n* @name ' + propertyName +
+                '\n* @instance\n';
 
             // If there are no comments at all no documentation will be generated, so
             // inject a comment node if necessary

--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -231,21 +231,27 @@ Visitor.prototype.visitNodeComments = function(node, parser, filename) {
 
     var BLOCK_COMMENT = 'Block';
 
+    // Ensure 'get' method in 'Object.defineProperty' is correctly documented
+    // 'Object.defineProperty' is an ExpressionStatement
     if (node.type === Syntax.ExpressionStatement &&
         node.expression.callee &&
         node.expression.callee.type === Syntax.MemberExpression &&
         node.expression.callee.object.name === 'Object' &&
         node.expression.callee.property.name === 'defineProperty') {
+        // node.expression.arguments[2] is the definition object passed to 'defineProperty'
         node.expression.arguments[2].properties.forEach(function (propertyNode) {
             if (propertyNode.key.name !== 'get') {
                 return;
             }
 
             var commentNode;
+            // get the name of the property being defined
             var propertyName = node.expression.arguments[1].value;
             var newComments = '*\r\n* @name ' + propertyName +
                 '\r\n* @instance\r\n';
 
+            // If there are no comments at all no documentation will be generated, so
+            // inject a comment node if necessary
             if (!propertyNode.leadingComments) {
                 propertyNode.leadingComments = [{
                     loc: propertyNode.loc,

--- a/lib/jsdoc/src/visitor.js
+++ b/lib/jsdoc/src/visitor.js
@@ -245,26 +245,32 @@ Visitor.prototype.visitNodeComments = function(node, parser, filename) {
                 return;
             }
 
-            var commentNode;
-            var propertyName = node.expression.arguments[1].value;
-            var newComments = '*\n* @name ' + propertyName +
-                '\n* @instance\n';
-
-            // If there are no comments at all no documentation will be generated, so
-            // inject a comment node if necessary
-            if (!propertyNode.leadingComments) {
-                propertyNode.leadingComments = [{
-                    loc: propertyNode.loc,
-                    range: propertyNode.range,
-                    type: 'Block',
-                    raw: '',
-                    value: ''
-                }];
+            // If there are no existing JSDoc comments ignore the node
+            if (!propertyNode.leadingComments ||
+                !propertyNode.leadingComments[0] ||
+                !propertyNode.leadingComments[0].value) {
+                return;
             }
 
-            commentNode = propertyNode.leadingComments[0];
-            commentNode.value = newComments + commentNode.value;
-            commentNode.raw = '/*' + commentNode.value + '\r\n*/';
+            var commentNode = propertyNode.leadingComments[0];
+            var propertyName = node.expression.arguments[1].value;
+            var newComments = '';
+
+            if (commentNode.value.indexOf('@instance') === -1) {
+                newComments += '\n* @instance';
+            }
+
+            if (commentNode.value.indexOf('@name') === -1) {
+                newComments += '\n* @name ' + propertyName;
+            }
+
+            if (newComments) {
+                newComments = newComments + '\n*';
+                // trim trailing whitespace and asterisks
+                commentNode.value = commentNode.value.replace(/\s*[*]*$/, '');
+                commentNode.value += newComments;
+                commentNode.raw = '/*' + commentNode.value + '*/';
+            }
         });
     }
 


### PR DESCRIPTION
This PR adds support for the `get` method when defined within a call to `Object.defineProperty`.

The functionality has been implemented with JSDoc comment injection to ensure that get methods with no JSDoc comment at all are included. Normally such a method would not appear at all in the generated documentation. With a `@type` comment, the method would be documented, but incorrectly - `@instance` and `@name` tags are also required for correct documentation. With these changes, `@instance` and `@name` can be omitted and the documentation will still be correct.

[PR 1315](https://github.com/jsdoc3/jsdoc/pull/1315) has been submitted to the JSDoc project for this changeset.